### PR TITLE
Fixed typo and error handling

### DIFF
--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -309,6 +309,14 @@ int nitro_report_syscall(struct kvm_vcpu *vcpu)
 
 	if (care) {
 		ed = kzalloc(sizeof(struct nitro_syscall_event_ht),GFP_KERNEL);
+
+		if (ed == NULL) {
+			printk(KERN_INFO "nitro: %s: "
+			       "Could not allocate space for new event.\n",
+			       __FUNCTION__);
+			return -ENOMEM;
+		}
+
 		ed->rsp = nitro_vcpu->syscall_event_rsp;
 		ed->cr3 = syscall_event_cr3;
 		nitro_hash_add(kvm, &ed, ed->rsp);

--- a/arch/x86/kvm/nitro_x86.c
+++ b/arch/x86/kvm/nitro_x86.c
@@ -8,167 +8,299 @@
 
 extern int kvm_set_msr_common(struct kvm_vcpu*, struct msr_data*);
 
-int nitro_set_syscall_trap(struct kvm *kvm,unsigned long *bitmap,int system_call_max){
-  int i;
-  struct kvm_vcpu *vcpu;
-  u64 efer;
-  struct msr_data msr_info;
+/*
+ * Common function following the activation of any system call watching.
+ * @param kvm	the virtual-machine-wide state to enable system call trapping
+ *		for all vcpus
+ */
+static void nitro_activate_syscall_trap(struct kvm *kvm)
+{
+	int i;
+	struct kvm_vcpu *vcpu;
+	u64 efer;
+	struct msr_data msr_info;
+
+	kvm->nitro.traps |= NITRO_TRAP_SYSCALL;
   
-  printk(KERN_INFO "nitro: set syscall trap\n");
-  
-  kvm->nitro.system_call_bm = bitmap;
-  kvm->nitro.system_call_max = system_call_max;
-  
-  kvm->nitro.traps |= NITRO_TRAP_SYSCALL;
-  
-  kvm_for_each_vcpu(i, vcpu, kvm){
-    //vcpu_load(vcpu);
-    nitro_vcpu_load(vcpu);
-    
-    kvm_get_msr_common(vcpu, MSR_EFER, &efer);
-    msr_info.index = MSR_EFER;
-    msr_info.data = efer & ~EFER_SCE;
-    msr_info.host_initiated = true;
-    kvm_set_msr_common(vcpu, &msr_info);
-    
-    init_completion(&vcpu->nitro.k_wait_cv);
-    
-    vcpu_put(vcpu);
-  }
-  
-  return 0;
+	kvm_for_each_vcpu(i, vcpu, kvm) {
+		struct nitro_vcpu *nitro_vcpu;
+
+		nitro_vcpu_load(vcpu);
+
+		nitro_vcpu = &vcpu->nitro;
+
+		kvm_get_msr_common(vcpu, MSR_EFER, &efer);
+		msr_info.index = MSR_EFER;
+		msr_info.data = efer & ~EFER_SCE;
+		msr_info.host_initiated = true;
+		kvm_set_msr_common(vcpu, &msr_info);
+
+		init_completion(&nitro_vcpu->k_wait_cv);
+		mutex_init(&nitro_vcpu->k_wait_cv_lock);
+
+		vcpu_put(vcpu);
+	}
 }
 
-int nitro_unset_syscall_trap(struct kvm *kvm){
-  int i;
-  struct kvm_vcpu *vcpu;
-  u64 efer;
-  struct msr_data msr_info;
-  struct nitro_syscall_event_ht *ed;
-  
-  printk(KERN_INFO "nitro: unset syscall trap\n");
-  
-  kvm_for_each_vcpu(i, vcpu, kvm){
-    //vcpu_load(vcpu);
-    
-    vcpu->nitro.event = 0;
-    //if waiters, wake up
-    //if(completion_done(&(vcpu->nitro.k_wait_cv)) == 0)
-    complete_all(&(vcpu->nitro.k_wait_cv));
-    
-    
-    nitro_vcpu_load(vcpu);
-    
-    kvm_get_msr_common(vcpu, MSR_EFER, &efer);
-    msr_info.index = MSR_EFER;
-    msr_info.data = efer | EFER_SCE;
-    msr_info.host_initiated = true;
-    kvm_set_msr_common(vcpu, &msr_info);
-    
+int nitro_set_syscall_trap(struct kvm *kvm, unsigned long *bitmap,
+			   int system_call_max)
+{
+	struct nitro *nitro = &kvm->nitro;
+	printk(KERN_INFO "nitro: set syscall trap\n");
 
-    
-    vcpu_put(vcpu);
-  }
-  
-  kvm->nitro.traps &= ~(NITRO_TRAP_SYSCALL);
-  if(kvm->nitro.system_call_bm != NULL){
-    kfree(kvm->nitro.system_call_bm);
-    kvm->nitro.system_call_bm = NULL;
-  }
-  kvm->nitro.system_call_max = 0;
-  
-  
-  hash_for_each(kvm->nitro.system_call_rsp_ht,i,ed,ht){
-    kfree(ed);
-  }
+	mutex_lock(&nitro->settings_lock);
+	if (nitro->watch_all_syscalls)
+		kfree(bitmap); /* All system calls are already watched. */
+	else if (nitro->system_call_bm == NULL) {
+		/* No system calls were previously watched. */
+		nitro->system_call_bm = bitmap;
+		nitro->system_call_max = system_call_max;
+	} else {
+		/* Use the larger system call bitmap. */
+		unsigned long *smaller_bm;
+		int smaller_max;
+		int word_i;
 
-  return 0;
+		if (system_call_max > nitro->system_call_max) {
+			smaller_bm = nitro->system_call_bm;
+			smaller_max = nitro->system_call_max;
+
+			nitro->system_call_bm = bitmap;
+			nitro->system_call_max = system_call_max;
+		} else {
+			smaller_bm = bitmap;
+			smaller_max = system_call_max;
+		}
+
+		for (word_i = 0;
+		     word_i < n_words_in_syscall_bitmap(smaller_max);
+		     word_i++) {
+			nitro->system_call_bm[word_i] |= smaller_bm[word_i];
+		}
+
+		kfree(smaller_bm);
+	}
+	mutex_unlock(&nitro->settings_lock);
+
+	nitro_activate_syscall_trap(kvm);
+
+	return 0;
 }
 
-void nitro_wait(struct kvm_vcpu *vcpu){
-  long rv;
-  
-  up(&(vcpu->nitro.n_wait_sem));
-  rv = wait_for_completion_interruptible_timeout(&(vcpu->nitro.k_wait_cv),msecs_to_jiffies(30000));
-  
-  if (rv == 0)
-    printk(KERN_INFO "nitro: %s: wait timed out\n",__FUNCTION__);
-  else if (rv < 0)
-    printk(KERN_INFO "nitro: %s: wait interrupted\n",__FUNCTION__);
-  
-  return;
+int nitro_set_all_syscall_trap(struct kvm *kvm)
+{
+	struct nitro *nitro = &kvm->nitro;
+	printk(KERN_INFO "nitro: set all syscall trap\n");
+
+	mutex_lock(&nitro->settings_lock);
+	nitro->watch_all_syscalls = true;
+	if (nitro->system_call_bm != NULL) {
+		kfree(nitro->system_call_bm);
+		nitro->system_call_bm = NULL;
+		nitro->system_call_max = 0;
+	}
+	mutex_unlock(&nitro->settings_lock);
+
+	nitro_activate_syscall_trap(kvm);
+
+	return 0;
 }
 
-int nitro_report_syscall(struct kvm_vcpu *vcpu){
-  unsigned long syscall_nr;
-  struct kvm *kvm;
-  struct nitro_syscall_event_ht *ed;
-  
-  kvm = vcpu->kvm;
-  
-  if(kvm->nitro.system_call_max > 0){
-    syscall_nr = kvm_register_read(vcpu, VCPU_REGS_RAX);
-    
-    if(syscall_nr > INT_MAX || syscall_nr > kvm->nitro.system_call_max || !test_bit((int)syscall_nr,kvm->nitro.system_call_bm))
-      return 0;
-  }
-  
-  ed = kzalloc(sizeof(struct nitro_syscall_event_ht),GFP_KERNEL);
-  ed->rsp = vcpu->nitro.syscall_event_rsp;
-  ed->cr3 = vcpu->nitro.syscall_event_cr3;
-  //hash_add(kvm->nitro.system_call_rsp_ht,&ed->ht,ed->rsp);
-  nitro_hash_add(kvm,&ed,ed->rsp);
-  
-  memset(&vcpu->nitro.event_data,0,sizeof(union event_data));
-  vcpu->nitro.event_data.syscall = vcpu->nitro.syscall_event_rsp;
+/*
+ * Remove an event entry from the hash table containing it, and free it.
+ * @param event_entry	the event to remove and free
+ */
+static inline void free_event_entry(struct nitro_syscall_event_ht *event_entry)
+{
+	hash_del(&event_entry->ht);
+	kfree(event_entry);
+}
 
-  nitro_wait(vcpu);
-  
-  return 0;
+int nitro_unset_syscall_trap(struct kvm *kvm)
+{
+	struct nitro *nitro_kvm = &kvm->nitro;
+	int i;
+	struct kvm_vcpu *vcpu;
+	u64 efer;
+	struct msr_data msr_info;
+	struct nitro_syscall_event_ht *ed;
+
+	printk(KERN_INFO "nitro: unset syscall trap\n");
+
+	clear_settings(nitro_kvm);
+
+	kvm_for_each_vcpu(i, vcpu, kvm) {
+		struct nitro_vcpu *nitro_vcpu = &vcpu->nitro;
+		nitro_vcpu->event = 0;
+
+		/*
+		 * Make sure there are no more calls to nitro_wait
+		 * that could block nitro_vcpu_load.
+		 */
+		while (!mutex_trylock(&nitro_vcpu->k_wait_cv_lock))
+			complete_all(&nitro_vcpu->k_wait_cv);
+
+		nitro_vcpu_load(vcpu);
+		mutex_unlock(&nitro_vcpu->k_wait_cv_lock);
+
+		/* Clear any remaining events. */
+		while (!down_trylock(&nitro_vcpu->n_wait_sem))
+			;
+
+		kvm_get_msr_common(vcpu, MSR_EFER, &efer);
+		msr_info.index = MSR_EFER;
+		msr_info.data = efer | EFER_SCE;
+		msr_info.host_initiated = true;
+		kvm_set_msr_common(vcpu, &msr_info);
+
+		vcpu_put(vcpu);
+	}
+
+	nitro_kvm->traps &= ~(NITRO_TRAP_SYSCALL);
+
+	hash_for_each(kvm->nitro.system_call_rsp_ht, i, ed, ht) {
+		free_event_entry(ed);
+	}
+
+	return 0;
+}
+
+void nitro_wait(struct kvm_vcpu *vcpu)
+{
+	struct nitro_vcpu *nitro_vcpu = &vcpu->nitro;
+	long rv;
+
+	up(&nitro_vcpu->n_wait_sem);
+
+	if (!mutex_trylock(&nitro_vcpu->k_wait_cv_lock))
+		return;
+
+	rv = wait_for_completion_interruptible_timeout(&nitro_vcpu->k_wait_cv,
+						       msecs_to_jiffies(30000));
+	mutex_unlock(&nitro_vcpu->k_wait_cv_lock);
+
+	if (rv == 0)
+		printk(KERN_INFO "nitro: %s: wait timed out\n", __FUNCTION__);
+	else if (rv < 0)
+		printk(KERN_INFO "nitro: %s: wait interrupted\n", __FUNCTION__);
+
+	return;
+}
+
+int nitro_report_syscall(struct kvm_vcpu *vcpu)
+{
+	struct kvm *kvm;
+	struct nitro *nitro;
+	unsigned long syscall_nr;
+	struct nitro_syscall_event_ht *ed;
+	int care = 1;
+
+	kvm = vcpu->kvm;
+	nitro = &kvm->nitro;
+
+	mutex_lock(&nitro->settings_lock);
+	if (nitro->system_call_bm != NULL) {
+		syscall_nr = kvm_register_read(vcpu, VCPU_REGS_RAX);
+
+		if (syscall_nr > INT_MAX ||
+		    syscall_nr > nitro->system_call_max ||
+		    !test_bit((int) syscall_nr, nitro->system_call_bm))
+			care = 0;
+	} else if (!nitro->watch_all_syscalls)
+		care = 0;
+	mutex_unlock(&nitro->settings_lock);
+
+	if (care) {
+		ed = kzalloc(sizeof(struct nitro_syscall_event_ht),GFP_KERNEL);
+		ed->rsp = vcpu->nitro.syscall_event_rsp;
+		ed->cr3 = vcpu->nitro.syscall_event_cr3;
+		nitro_hash_add(kvm,&ed,ed->rsp);
+
+		memset(&vcpu->nitro.event_data, 0, sizeof(union event_data));
+		vcpu->nitro.event_data.syscall = vcpu->nitro.syscall_event_rsp;
+
+		nitro_wait(vcpu);
+	}
+
+	return 0;
+}
+
+/*
+ * Check if system call watching has already been disabled.
+ * @param nitro	contains the system call settings
+ * @return	true iff the settings specify neither specific system calls,
+ *		nor that all system calls should be watched
+ */
+inline static bool ignore_events(struct nitro *nitro)
+{
+	bool ignore;
+
+	mutex_lock(&nitro->settings_lock);
+
+	ignore = (nitro->system_call_bm == NULL) && !nitro->watch_all_syscalls;
+
+	mutex_unlock(&nitro->settings_lock);
+
+	return ignore;
 }
 
 int nitro_report_sysret(struct kvm_vcpu *vcpu){
-  struct kvm *kvm;
-  struct nitro_syscall_event_ht *ed;
-  
-  kvm = vcpu->kvm;
-  
-  hash_for_each_possible(kvm->nitro.system_call_rsp_ht, ed, ht, vcpu->nitro.syscall_event_rsp){
-    if((ed->rsp == vcpu->nitro.syscall_event_rsp) && (ed->cr3 == vcpu->nitro.syscall_event_cr3)){
-      hash_del(&ed->ht);
-      kfree(ed);
+	struct nitro_vcpu *nitro_vcpu = &vcpu->nitro;
+	struct kvm *kvm;
+	struct nitro_syscall_event_ht *ed;
+	int ignore;
+
+	kvm = vcpu->kvm;
+
+	ignore = ignore_events(&kvm->nitro);
+
+	if (ignore)
+		return 0;
+
+	hash_for_each_possible(kvm->nitro.system_call_rsp_ht, ed, ht,
+			       nitro_vcpu->syscall_event_rsp) {
+		if((ed->rsp == nitro_vcpu->syscall_event_rsp) &&
+		   (ed->cr3 == nitro_vcpu->syscall_event_cr3)) {
+			free_event_entry(ed);
       
-      memset(&vcpu->nitro.event_data,0,sizeof(union event_data));
-      vcpu->nitro.event_data.syscall = vcpu->nitro.syscall_event_rsp;
+			memset(&nitro_vcpu->event_data, 0,
+			       sizeof(union event_data));
+			nitro_vcpu->event_data.syscall = nitro_vcpu->
+							 syscall_event_rsp;
       
-      nitro_wait(vcpu);
-      break;
-    }
-  }
-  
-  return 0;
+			nitro_wait(vcpu);
+			break;
+		}
+	}
+
+	return 0;
 }
 
-int nitro_report_event(struct kvm_vcpu *vcpu){
-  int r;
-  
-  r = 0;
-  
-  switch(vcpu->nitro.event){
-    case KVM_NITRO_EVENT_ERROR:
-      nitro_wait(vcpu);
-      break;
-    case KVM_NITRO_EVENT_SYSCALL:
-      r = nitro_report_syscall(vcpu);
-      break;
-    case KVM_NITRO_EVENT_SYSRET:
-      r = nitro_report_sysret(vcpu);
-      break;
-    default:
-      printk(KERN_INFO "nitro: %s: unknown event encountered (%d)\n",__FUNCTION__,vcpu->nitro.event);
-  }
-  vcpu->nitro.event = 0;
-  return r;
+int nitro_report_event(struct kvm_vcpu *vcpu)
+{
+	int r = 0;
+
+	switch(vcpu->nitro.event) {
+		case KVM_NITRO_EVENT_ERROR:
+			if (ignore_events(&(vcpu->kvm->nitro))) {
+				r = 0;
+				break;
+			}
+			nitro_wait(vcpu);
+			break;
+		case KVM_NITRO_EVENT_SYSCALL:
+			r = nitro_report_syscall(vcpu);
+			break;
+		case KVM_NITRO_EVENT_SYSRET:
+			r = nitro_report_sysret(vcpu);
+			break;
+		default:
+			printk(KERN_INFO "nitro: %s: "
+			       "unknown event encountered (%d)\n", __FUNCTION__,
+			       vcpu->nitro.event);
+	}
+	vcpu->nitro.event = 0;
+	return r;
 }
 
 inline u64 nitro_get_efer(struct kvm_vcpu *vcpu){

--- a/arch/x86/kvm/nitro_x86.h
+++ b/arch/x86/kvm/nitro_x86.h
@@ -3,8 +3,16 @@
 
 #include <linux/kvm_host.h>
 
-int nitro_set_syscall_trap(struct kvm*,unsigned long*,int);
-int nitro_unset_syscall_trap(struct kvm*);
+int nitro_set_syscall_trap(struct kvm *kvm, unsigned long *bitmap,
+			   int system_call_max);
+/*
+ * Enable watching all system calls.
+ * @param kvm	the virtual-machine-wide state
+ *		containing the system call settings
+ * @return	0
+ */
+int nitro_set_all_syscall_trap(struct kvm *kvm);
+int nitro_unset_syscall_trap(struct kvm *kvm);
 
 void nitro_wait(struct kvm_vcpu*);
 int nitro_report_syscall(struct kvm_vcpu*);

--- a/arch/x86/kvm/nitro_x86.h
+++ b/arch/x86/kvm/nitro_x86.h
@@ -12,6 +12,31 @@ int nitro_set_syscall_trap(struct kvm *kvm, unsigned long *bitmap,
  * @return	0
  */
 int nitro_set_all_syscall_trap(struct kvm *kvm);
+/*
+ * Start watching a process, identified by its cr3 value.
+ * This function does not activate system call trapping,
+ * and therefore can be run at any time.
+ * @param kvm		the virtual-machine-wide state
+ *			containing the system call settings
+ * @param process_cr3	the identifier for the process to watch
+ * @return		0 on success,
+ *			-ENOMEM if no space could be allocated
+ *				for the new process,
+ *			-EINVAL if the process is already watched
+ */
+int nitro_add_process_trap(struct kvm *kvm, ulong process_cr3);
+/*
+ * Stop watching a process, identified by its cr3 value.
+ * If that was the last process, all processes will be watched,
+ * and therefore can be run at any time.
+ * This function does not deactivate system call trapping.
+ * @param kvm		the virtual-machine-wide state
+ *			containing the system call settings
+ * @param process_cr3	the identifier for the process to unwatch
+ * @return		0 on success,
+ *			-EINVAL if the process was not previously watched
+ */
+int nitro_remove_process_trap(struct kvm *kvm, ulong process_cr3);
 int nitro_unset_syscall_trap(struct kvm *kvm);
 
 void nitro_wait(struct kvm_vcpu*);

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -3872,52 +3872,59 @@ long kvm_arch_vm_ioctl(struct file *filp,
 		long unsigned *bitmap;
 
 		r = -EFAULT;
-		if (copy_from_user(&user_sct, argp, sizeof(struct nitro_syscall_trap)))
+		if (copy_from_user(&user_sct, argp,
+				   sizeof(struct nitro_syscall_trap)))
 			goto out;
 		
-		if(user_sct.size > 0){
+		if(user_sct.size > 0) {
 			r = -ENOMEM;
-			syscalls = kmalloc(user_sct.size * sizeof(int), GFP_KERNEL);
+			syscalls = kmalloc(user_sct.size * sizeof(int),
+					   GFP_KERNEL);
 			if (syscalls == NULL)
 				goto out;
 			
 			r = -EFAULT;
-			if (copy_from_user(syscalls, user_sct.syscalls, user_sct.size * sizeof(int))){
+			if (copy_from_user(syscalls, user_sct.syscalls,
+					   user_sct.size * sizeof(int))){
 				kfree(syscalls);
 				goto out;
 			}
 			
 			system_call_max = 0;
-			for(i=0;i<user_sct.size;i++)
+			for(i=0; i < user_sct.size; i++)
 				if(syscalls[i] > system_call_max)
 					system_call_max = syscalls[i];
-				
-			bm_size = ((system_call_max / (sizeof(unsigned long) * 8)) + 1) * (sizeof(unsigned long) * 8);
-  
+
+			bm_size = n_words_in_syscall_bitmap(system_call_max) *
+				  N_BITS_IN_BITMAP_WORD;
+
 			r = -ENOMEM;
 			bitmap = kmalloc(bm_size / 8, GFP_KERNEL);
-			if (bitmap == NULL){
+			if (bitmap == NULL) {
 				kfree(syscalls);
 				goto out;
 			}
+
+			bitmap_zero(bitmap, bm_size);
 			
-			bitmap_zero(bitmap,bm_size);
-			
-			for(i=0;i<user_sct.size;i++)
-			  set_bit(syscalls[i],bitmap);
+			for(i=0; i<user_sct.size; i++)
+				set_bit(syscalls[i],bitmap);
 			
 			kfree(syscalls);
-		}
-		else{
+		} else {
 			bitmap = NULL;
 			system_call_max = 0;
 		}
-	  
-		r = nitro_set_syscall_trap(kvm,bitmap,system_call_max);
+
+		r = nitro_set_syscall_trap(kvm, bitmap, system_call_max);
 		break;
 	}
 	case KVM_NITRO_UNSET_SYSCALL_TRAP: {
 		r = nitro_unset_syscall_trap(kvm);
+		break;
+	}
+	case KVM_NITRO_SET_ALL_SYSCALL_TRAP: {
+		r = nitro_set_all_syscall_trap(kvm);
 		break;
 	}
 
@@ -6131,7 +6138,7 @@ static int __vcpu_run(struct kvm_vcpu *vcpu)
 		if (r <= 0)
 			break;
 		
-		if(vcpu->nitro.event)
+		if (vcpu->nitro.event)
 			nitro_report_event(vcpu);
 
 		clear_bit(KVM_REQ_PENDING_TIMER, &vcpu->requests);

--- a/arch/x86/kvm/x86.c
+++ b/arch/x86/kvm/x86.c
@@ -3927,6 +3927,28 @@ long kvm_arch_vm_ioctl(struct file *filp,
 		r = nitro_set_all_syscall_trap(kvm);
 		break;
 	}
+	case KVM_NITRO_ADD_PROCESS_TRAP: {
+		ulong process_cr3;
+
+		if (copy_from_user(&process_cr3, argp, sizeof(process_cr3))) {
+			r = -EFAULT;
+			goto out;
+		}
+
+		r = nitro_add_process_trap(kvm, process_cr3);
+		break;
+	}
+	case KVM_NITRO_REMOVE_PROCESS_TRAP: {
+		ulong process_cr3;
+
+		if (copy_from_user(&process_cr3, argp, sizeof(process_cr3))) {
+			r = -EFAULT;
+			goto out;
+		}
+
+		r = nitro_remove_process_trap(kvm, process_cr3);
+		break;
+	}
 
 	default:
 		;

--- a/include/linux/nitro.h
+++ b/include/linux/nitro.h
@@ -37,6 +37,8 @@ union event_data{
 					     struct nitro_syscall_trap)
 #define KVM_NITRO_UNSET_SYSCALL_TRAP	_IO(KVMIO, 0xE4)
 #define KVM_NITRO_SET_ALL_SYSCALL_TRAP	_IO(KVMIO, 0xE5)
+#define KVM_NITRO_ADD_PROCESS_TRAP	_IOW(KVMIO, 0xE6, ulong)
+#define KVM_NITRO_REMOVE_PROCESS_TRAP	_IOW(KVMIO, 0xE7, ulong)
 
 //VCPU functions
 #define KVM_NITRO_GET_EVENT	_IOR(KVMIO, 0xE8, union event_data)

--- a/include/linux/nitro.h
+++ b/include/linux/nitro.h
@@ -44,5 +44,7 @@ union event_data{
 #define KVM_NITRO_SET_REGS              _IOW(KVMIO,  0xE8, struct kvm_regs)
 #define KVM_NITRO_GET_SREGS             _IOR(KVMIO,  0xE9, struct kvm_sregs)
 #define KVM_NITRO_SET_SREGS             _IOW(KVMIO,  0xEA, struct kvm_sregs)
+#define KVM_NITRO_TRANSLATE		_IOWR(KVMIO, 0xEB, \
+					      struct kvm_translation)
 
 #endif //NITRO_H_

--- a/include/linux/nitro.h
+++ b/include/linux/nitro.h
@@ -32,19 +32,21 @@ union event_data{
 #define KVM_NITRO_ATTACH_VM  	_IOW(KVMIO, 0xE1, pid_t)
 
 //VM functions
-#define KVM_NITRO_ATTACH_VCPUS	_IOR(KVMIO, 0xE2, struct nitro_vcpus)
-#define KVM_NITRO_SET_SYSCALL_TRAP _IOW(KVMIO, 0xE3, struct nitro_syscall_trap)
-#define KVM_NITRO_UNSET_SYSCALL_TRAP _IO(KVMIO, 0xE4)
+#define KVM_NITRO_ATTACH_VCPUS		_IOR(KVMIO, 0xE2, struct nitro_vcpus)
+#define KVM_NITRO_SET_SYSCALL_TRAP	_IOW(KVMIO, 0xE3, \
+					     struct nitro_syscall_trap)
+#define KVM_NITRO_UNSET_SYSCALL_TRAP	_IO(KVMIO, 0xE4)
+#define KVM_NITRO_SET_ALL_SYSCALL_TRAP	_IO(KVMIO, 0xE5)
 
 //VCPU functions
-#define KVM_NITRO_GET_EVENT	_IOR(KVMIO, 0xE5, union event_data)
-#define KVM_NITRO_CONTINUE	_IO(KVMIO, 0xE6)
+#define KVM_NITRO_GET_EVENT	_IOR(KVMIO, 0xE8, union event_data)
+#define KVM_NITRO_CONTINUE	_IO(KVMIO, 0xE9)
 
-#define KVM_NITRO_GET_REGS              _IOR(KVMIO,  0xE7, struct kvm_regs)
-#define KVM_NITRO_SET_REGS              _IOW(KVMIO,  0xE8, struct kvm_regs)
-#define KVM_NITRO_GET_SREGS             _IOR(KVMIO,  0xE9, struct kvm_sregs)
-#define KVM_NITRO_SET_SREGS             _IOW(KVMIO,  0xEA, struct kvm_sregs)
-#define KVM_NITRO_TRANSLATE		_IOWR(KVMIO, 0xEB, \
+#define KVM_NITRO_GET_REGS              _IOR(KVMIO,  0xEA, struct kvm_regs)
+#define KVM_NITRO_SET_REGS              _IOW(KVMIO,  0xEB, struct kvm_regs)
+#define KVM_NITRO_GET_SREGS             _IOR(KVMIO,  0xEC, struct kvm_sregs)
+#define KVM_NITRO_SET_SREGS             _IOW(KVMIO,  0xED, struct kvm_sregs)
+#define KVM_NITRO_TRANSLATE		_IOWR(KVMIO, 0xEF, \
 					      struct kvm_translation)
 
 #endif //NITRO_H_

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -65,16 +65,12 @@ inline static void remove_process(struct nitro_process_node *process_node)
 }
 
 /*
- * Stop watching any system calls.
+ * Assuming no other thread is accessing the settings,
+ * clear the system call settings.
  * @param nitro	contains the system call settings for the virtual machine
  */
-inline static void clear_settings(struct nitro *nitro)
+inline static void clear_syscall_settings(struct nitro *nitro)
 {
-	struct nitro_process_node *process_node;
-	int dummy_bkt;
-
-	mutex_lock(&nitro->settings_lock);
-
 	if (nitro->system_call_bm != NULL) {
 		unsigned long *system_call_bm = nitro->system_call_bm;
 
@@ -83,6 +79,20 @@ inline static void clear_settings(struct nitro *nitro)
 		kfree(system_call_bm);
 	} else if (nitro->watch_all_syscalls)
 		nitro->watch_all_syscalls = false;
+}
+
+/*
+ * Stop watching any system calls, and clear the set of watched processes.
+ * @param nitro	contains the trap settings for the virtual machine
+ */
+inline static void clear_settings(struct nitro *nitro)
+{
+	struct nitro_process_node *process_node;
+	int dummy_bkt;
+
+	mutex_lock(&nitro->settings_lock);
+
+	clear_syscall_settings(nitro);
 
 	hash_for_each(nitro->process_watch_ht, dummy_bkt, process_node, node) {
 		remove_process(process_node);

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -39,8 +39,8 @@ int nitro_vcpu_load(struct kvm_vcpu*);
 
 struct kvm* nitro_get_vm_by_creator(pid_t);
 
-int nitro_iotcl_num_vms(void);
-int nitro_iotcl_attach_vcpus(struct kvm*, struct nitro_vcpus*);
+int nitro_ioctl_num_vms(void);
+int nitro_ioctl_attach_vcpus(struct kvm*, struct nitro_vcpus*);
 
 
 void nitro_create_vm_hook(struct kvm*);

--- a/include/linux/nitro_main.h
+++ b/include/linux/nitro_main.h
@@ -6,16 +6,71 @@
 #include <linux/kvm_host.h>
 #include <linux/nitro.h>
 #include <linux/hashtable.h>
+#include <linux/mutex.h>
 
 #define NITRO_TRAP_SYSCALL 1UL
 //#define NITRO_TRAP_XYZ  (1UL << 1)
 
-struct nitro{
-  uint32_t traps; //determines whether the syscall trap is globally set
-  unsigned long *system_call_bm;
-  unsigned int system_call_max;
-  DECLARE_HASHTABLE(system_call_rsp_ht,7);
+/* nitro's part of the virtual-machine-wide state */
+struct nitro {
+	/* determines whether the syscall trap is globally set */
+	uint32_t traps;
+	/*
+	 * lock for all of the below fields,
+	 * which indicate which events to watch
+	 */
+	struct mutex settings_lock;
+	/* Watch all system calls. Off by default. */
+	bool watch_all_syscalls;
+	/*
+	 * If only a limited set of system calls are watched,
+	 * this bitmap indicates them. NULL by default.
+	 */
+	unsigned long *system_call_bm;
+	/*
+	 * If only a limited set of system calls are watched,
+	 * this integer indicates the highest one. 0 by default.
+	 */
+	unsigned int system_call_max;
+	/* The prior syscall events, for checking against return events. */
+	DECLARE_HASHTABLE(system_call_rsp_ht,7);
 };
+
+/*
+ * Stop watching any system calls.
+ * @param nitro	contains the system call settings for the virtual machine
+ */
+inline static void clear_settings(struct nitro *nitro)
+{
+	mutex_lock(&nitro->settings_lock);
+
+	if (nitro->system_call_bm != NULL) {
+		unsigned long *system_call_bm = nitro->system_call_bm;
+
+		nitro->system_call_bm = NULL;
+		nitro->system_call_max = 0;
+		kfree(system_call_bm);
+	} else if (nitro->watch_all_syscalls)
+		nitro->watch_all_syscalls = false;
+
+	mutex_unlock(&nitro->settings_lock);
+}
+
+/* the number of bits per bitmap word */
+#define N_BITS_IN_BITMAP_WORD		(8 * sizeof(unsigned long))
+/*
+ * Round up the number of words required to store even the largest system call
+ * in a bitmap.
+ * @param system_call_max	the largest system call,
+ *				which is one less than the
+ *				unrounded number of needed bits
+ * @return			number of words required
+ *				to store the largest system call
+ */
+static inline unsigned n_words_in_syscall_bitmap(int system_call_max)
+{
+	return system_call_max / N_BITS_IN_BITMAP_WORD + 1;
+}
 
 struct nitro_syscall_event_ht{
   ulong rsp;
@@ -23,13 +78,28 @@ struct nitro_syscall_event_ht{
   struct hlist_node ht;
 };
 
-struct nitro_vcpu{
-  struct completion k_wait_cv;
-  struct semaphore n_wait_sem;
-  int event;
-  union event_data event_data;
-  ulong syscall_event_rsp;
-  ulong syscall_event_cr3;
+/* nitro's part of the per-vcpu state */
+struct nitro_vcpu {
+	/*
+	 * lock used to make sure that
+	 * when nitro_unset_syscall_trap is between completing k_wait_cv
+	 * and loading the vcpu,
+	 * there is no call to nitro_wait that is holding the vcpu,
+	 * and newly waiting on k_wait_cv
+	 */
+	struct mutex k_wait_cv_lock;
+	/* After an event, suspend execution until the continue command. */
+	struct completion k_wait_cv;
+	/* Wait for event to fetch. */
+	struct semaphore n_wait_sem;
+	/* the event type */
+	int event;
+	/* additional event information */
+	union event_data event_data;
+	/* the last stack pointer identifies the system call for one task */
+	ulong syscall_event_rsp;
+	/* identifies the task */
+	ulong syscall_event_cr3;
 };
 
 

--- a/virt/kvm/kvm_main.c
+++ b/virt/kvm/kvm_main.c
@@ -2568,7 +2568,7 @@ static long kvm_vm_ioctl(struct file *filp,
 		int i;
 		struct nitro_vcpus nvcpus;
 
-		r = nitro_iotcl_attach_vcpus(kvm,&nvcpus);
+		r = nitro_ioctl_attach_vcpus(kvm,&nvcpus);
 		if (r)
 			goto out;
 
@@ -2734,7 +2734,7 @@ static long kvm_dev_ioctl(struct file *filp,
 		r = -EOPNOTSUPP;
 		break;
 	case KVM_NITRO_NUM_VMS:
-		r = nitro_iotcl_num_vms();
+		r = nitro_ioctl_num_vms();
 		break;
 	case KVM_NITRO_ATTACH_VM: {
 		pid_t creator;

--- a/virt/kvm/kvm_main.c
+++ b/virt/kvm/kvm_main.c
@@ -2044,6 +2044,21 @@ out_free2:
 		r = kvm_arch_vcpu_ioctl_set_sregs(vcpu, kvm_sregs);
 		goto out_no_put;
 	}
+	case KVM_NITRO_TRANSLATE: {
+		struct kvm_translation tr;
+
+		r = -EFAULT;
+		if (copy_from_user(&tr, argp, sizeof tr))
+			goto out_no_put;
+		r = kvm_arch_vcpu_ioctl_translate(vcpu, &tr);
+		if (r)
+			goto out_no_put;
+		r = -EFAULT;
+		if (copy_to_user(argp, &tr, sizeof tr))
+			goto out_no_put;
+		r = 0;
+		goto out_no_put;
+	}
 #if defined(CONFIG_S390) || defined(CONFIG_PPC) || defined(CONFIG_MIPS)
 	case KVM_S390_INTERRUPT:
 	case KVM_INTERRUPT:

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -96,7 +96,7 @@ void nitro_destroy_vcpu_hook(struct kvm_vcpu *vcpu){
   vcpu->nitro.event = 0;
 }
 
-int nitro_iotcl_num_vms(void){
+int nitro_ioctl_num_vms(void){
   struct kvm *kvm;
   int rv = 0;
   
@@ -108,7 +108,7 @@ int nitro_iotcl_num_vms(void){
   return rv;
 }
 
-int nitro_iotcl_attach_vcpus(struct kvm *kvm, struct nitro_vcpus *nvcpus){
+int nitro_ioctl_attach_vcpus(struct kvm *kvm, struct nitro_vcpus *nvcpus){
   int r,i;
   struct kvm_vcpu *v;
   

--- a/virt/kvm/nitro_main.c
+++ b/virt/kvm/nitro_main.c
@@ -76,6 +76,7 @@ void nitro_create_vm_hook(struct kvm *kvm){
 	nitro->system_call_max = 0;
 	nitro->watch_all_syscalls = false;
 	hash_init(nitro->system_call_rsp_ht);
+	hash_init(nitro->process_watch_ht);
 	mutex_init(&nitro->settings_lock);
 }
 


### PR DESCRIPTION
Fixed typo in function names that are supposed to include "ioctl".
Removed infinite loop in error condition of nitro_set_syscall_trap.
